### PR TITLE
Allow 'o' as an itemized list character

### DIFF
--- a/lists-by-indent/xsl/lists.xsl
+++ b/lists-by-indent/xsl/lists.xsl
@@ -23,7 +23,7 @@
 
   <xsl:variable name="hub:orderedlist-mark-open-quote-regex" as="xs:string" select="'[‚„«‹›»“‘]?'"/>
   <xsl:variable name="hub:itemizedlist-mark-chars-regex" as="xs:string"
-    select="'([&#xb7;&#x336;&#x25aa;&#x25a1;&#x25cf;&#x25fb;&#x25fc;&#x25fd;&#x25b6;&#x25cf;&#x2212;&#x2022;\p{So}\p{Pd}&#x23af;&#xF0B7;&#xF0BE;&#61485;-])'"/>
+    select="'([&#xb7;&#x336;&#x25aa;&#x25a1;&#x25cf;&#x25fb;&#x25fc;&#x25fd;&#x25b6;&#x25cf;&#x2212;&#x2022;\p{So}\p{Pd}&#x23af;&#xF0B7;&#xF0BE;&#61485;o-])'"/>
   <!-- [A-Z] not followed by dot: confusion with people’s initials in indented paras -->
   <xsl:variable name="hub:orderedlist-mark-chars-regex" as="xs:string"
     select="'[\(\[]?(([ivx]+|[IVX]+|[a-z]|[A-Z]|\p{Zs}*[0-9]+)(\.\d+)*)[.:]?[\)\]]?'"/>


### PR DESCRIPTION
In Microsoft word, the second level of the default bulleted list is actually the 'o' character in the Courier New font.

Without this change such lists will be a <orderedlist numeration="loweralpha"> with <listitem override="o">for each element.